### PR TITLE
Migrations must be public to be seen by FluentMigrator & Primary Keys on creation

### DIFF
--- a/FluentMigrator.NHibernate/ExpressionExporter.cs
+++ b/FluentMigrator.NHibernate/ExpressionExporter.cs
@@ -61,16 +61,6 @@ namespace FluentMigrator.NHibernate
                     Columns = GetTableColumns(table, mapping),
                     TableDescription = table.Comment
                 };
-                yield return new CreateConstraintExpression(ConstraintType.PrimaryKey)
-                {
-                    Constraint = new ConstraintDefinition(ConstraintType.PrimaryKey)
-                    {
-                        ConstraintName = "PK_" + table.Name,
-                        Columns = table.PrimaryKey.ColumnIterator.Select(c => c.Name).ToList(),
-                        SchemaName = table.Schema,
-                        TableName = table.Name
-                    }
-                };
                 foreach (var p in GetUniqueKeys(table)) yield return p;
 
             }
@@ -259,6 +249,10 @@ namespace FluentMigrator.NHibernate
         private string _defaultCatalog;
         private string _defaultSchema;
 
+        private bool IsPrimaryKey(Table table, Column c) {
+            return table.HasPrimaryKey && table.PrimaryKey.ColumnIterator.Any (x => x.Equals (c));
+        }
+
         private ColumnDefinition ColumnDefinition(Table table, IMapping mapping, Column c, int i)
         {
             var columnDefinition = new ColumnDefinition();
@@ -286,7 +280,7 @@ namespace FluentMigrator.NHibernate
             }
 
             columnDefinition.DefaultValue = c.DefaultValue;
-            columnDefinition.IsPrimaryKey = false;//IsPrimaryKey(c, table);
+            columnDefinition.IsPrimaryKey = IsPrimaryKey(table, c);
             columnDefinition.IsNullable = c.IsNullable;
             columnDefinition.IsUnique = c.IsUnique;
             columnDefinition.IsIdentity = i == 0 && table.IdentifierValue!= null && table.IdentifierValue.IsIdentityColumn(_dialect);

--- a/FluentMigrator.NHibernate/MigrationConfigurationBase.cs
+++ b/FluentMigrator.NHibernate/MigrationConfigurationBase.cs
@@ -108,7 +108,7 @@ namespace FluentMigrator.NHibernate
 
         public static List<MigrationExpressionBase> GetFromExpressionList(Assembly migrationsAssembly)
         {
-            var lastMigration = migrationsAssembly.DefinedTypes.Where(t => t.BaseType == typeof (Migration))
+            var lastMigration = migrationsAssembly.ExportedTypes.Where(t => t.BaseType == typeof (Migration))
                 .Where(s => HasConfigurationData(s))
                 .OrderBy(t => GetVersion(t))
                 .LastOrDefault();

--- a/FluentMigrator.NHibernate/Templates/CSharp/Migration.cs
+++ b/FluentMigrator.NHibernate/Templates/CSharp/Migration.cs
@@ -52,7 +52,7 @@ namespace FluentMigrator.NHibernate.Templates.CSharp
             tw.Write("\t[Migration({0:00000000})]",Version);
             tw.WriteLine();
 
-            tw.WriteLine("\tinternal class "+Name+" : Migration");
+            tw.WriteLine("\tpublic class "+Name+" : Migration");
             tw.WriteLine("\t{");
             tw.WriteLine();
             tw.Write("\tpublic const string ConfigurationData = \"");


### PR DESCRIPTION
Migrations would not be found by FluentMigrator because they were internal.
Adding Primary Keys after creating a table doesn't work when the table is having an identity.
